### PR TITLE
fix: add safety check to override dome status and report dome as closed

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -34,12 +34,20 @@ export async function cacheResult(config: Config, params: string | NightlyDigest
 
 // get last exposure along with exposure_count
 export function extractCurrent(data: NightlyDigestBaseResponse) {
-    const { exposures, on_sky_exposures_count: exposuresCount } = data; // exposures_count is all exposures, on_sky_exposures_count is the more relevant count 
+    const { exposures, on_sky_exposures_count: exposuresCount, obs_end } = data; // exposures_count is all exposures, on_sky_exposures_count is the more relevant count 
     const lastExposure = exposures.length > 0 ? exposures[exposures.length - 1] : null;
+    
+    // Sometimes the dome was closed _after_ the last exposure. If `domeAutoCloseLimitMS` hours have passed since obs_end we should report the dome is closed.
+    const now = new Date();
+    // obs_end is a date string without a set timezone. Concatinating "Z" will force Date() to parse this as UTC-0.
+    const obsEnd = new Date(obs_end + "Z");
+    const domeAutoCloseLimitMS = 2 * 60 * 60 * 1000; // 2 Hours
+    const reportDomeIsClosed = (now.getTime() - obsEnd.getTime()) > domeAutoCloseLimitMS;
 
+    
     return {
         last_exposure: lastExposure,
-        last_can_see_sky: lastExposure?.can_see_sky ?? null,
+        last_can_see_sky: reportDomeIsClosed ? false : lastExposure?.can_see_sky ?? null,
         exposures_count: exposuresCount ?? 0
     }
 }


### PR DESCRIPTION
## What this change does
resolves #15 

This PR adds safety check to override dome status and report dome as closed if more than 2 hours have passed since the end of the observation period.

## Note
Because the `obs_end` timestamp comes through as a string without a set timezone, `new Date()` new date would have parsed it as the environments local time (AZ for me, who knows in GCP). We can force `Date()` to parse it as UTC-0 as intended by concatenating a `Z` to the timestamp string.

## Testing
I tested this change by running the client locally and hitting the `/current-exposure-count` via Postman.
I also ran the `yarn test` command and all tests pass.